### PR TITLE
Correct argument format for Busybox mktemp

### DIFF
--- a/dmenu_bw
+++ b/dmenu_bw
@@ -232,7 +232,7 @@ edit () { #^
     # create secure temporary files for editing vault items
     tmpDir=$(mktemp -d /tmp/dmenu_bw.XXXXXX)
     chmod 700 "$tmpDir"
-    newItem=$(mktemp "${tmpDir}/dmenu_bw.XXXXXX.json")
+    newItem=$(mktemp "${tmpDir}/dmenu_bw.json.XXXXXX")
     chmod 600 "$newItem"
     echo "$1" | jq > "$newItem"
 

--- a/dmenu_bw
+++ b/dmenu_bw
@@ -230,9 +230,9 @@ edit () { #^
     # $2: item id
 
     # create secure temporary files for editing vault items
-    tmpDir=$(mktemp -d /tmp/dmenu_bw.XXXXX)
+    tmpDir=$(mktemp -d /tmp/dmenu_bw.XXXXXX)
     chmod 700 "$tmpDir"
-    newItem=$(mktemp "${tmpDir}/dmenu_bw.XXXXX.json")
+    newItem=$(mktemp "${tmpDir}/dmenu_bw.XXXXXX.json")
     chmod 600 "$newItem"
     echo "$1" | jq > "$newItem"
 


### PR DESCRIPTION
Busybox mktemp requires there to be at least 6 Xs and for them to be at the end of the argument. Otherwise it returns nothing leaving $tmpDir and $newItem empty. GNU mktemp works fine either way.